### PR TITLE
fix compatibilities issues with new version of sequelize

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,18 +89,18 @@ filter[age][gt]=100&filter[age][lt]=10&filter[age][_condition]=or&filter[name][i
 }
 // getWhereQuery()
 {
-  [Sequelize.Op.or]: {
-    [Sequelize.Op.or]: [{
+  [Op.or]: {
+    [Op.or]: [{
       age: {
-        [Sequelize.Op.gt]: 100,
+        [Op.gt]: 100,
       },
     }, {
       age: {
-        [Sequelize.Op.lt]: 10,
+        [Op.lt]: 10,
       },
     }],
     name: {
-      [Sequelize.Op.like]: '%john%',
+      [Op.like]: '%john%',
     },
   },
 }
@@ -126,23 +126,23 @@ Git repository with DB tests: https://github.com/segemun/sequelize-search-builde
 | Request Option|Sequelize Symbol         |Description |
 |---------------|-------------------------|------------|
 | eq (=)        | = (no Symbol)           | Equal
-| gt            | Sequelize.Op.gt         | Greater than
-| gte           | Sequelize.Op.gte        | Greater than or equal
-| lt            | Sequelize.Op.lt         | Less than
-| lte           | Sequelize.Op.lte        | Less than or equal
-| ne            | Sequelize.Op.ne         | Not equal
-| between       | Sequelize.Op.between    | Between [value1, value2]
-| notBetween    | Sequelize.Op.notBetween | Not Between [value1, value2]
-| in            | Sequelize.Op.in         | In value list [value1, value2, ...]
-| notIn         | Sequelize.Op.notIn      | Not in value list [value1, value2, ...]
-| like          | Sequelize.Op.like       | Like search (%value, value%, %value%)
-| notLike       | Sequelize.Op.notLike    | Not like search (%value, value%, %value%)
-| iLike         | Sequelize.Op.iLike      | case insensitive LIKE (PG only)
-| notILike      | Sequelize.Op.notILike   | case insensitive NOT LIKE (PG only)
-| regexp        | Sequelize.Op.regexp     | Regexp (MySQL and PG only)
-| notRegexp     | Sequelize.Op.notRegexp  | Not Regexp (MySQL and PG only)
-| iRegexp       | Sequelize.Op.iRegexp    | iRegexp (case insensitive) (PG only)
-| notIRegexp    | Sequelize.Op.notIRegexp | notIRegexp (case insensitive) (PG only)
+| gt            | Op.gt         | Greater than
+| gte           | Op.gte        | Greater than or equal
+| lt            | Op.lt         | Less than
+| lte           | Op.lte        | Less than or equal
+| ne            | Op.ne         | Not equal
+| between       | Op.between    | Between [value1, value2]
+| notBetween    | Op.notBetween | Not Between [value1, value2]
+| in            | Op.in         | In value list [value1, value2, ...]
+| notIn         | Op.notIn      | Not in value list [value1, value2, ...]
+| like          | Op.like       | Like search (%value, value%, %value%)
+| notLike       | Op.notLike    | Not like search (%value, value%, %value%)
+| iLike         | Op.iLike      | case insensitive LIKE (PG only)
+| notILike      | Op.notILike   | case insensitive NOT LIKE (PG only)
+| regexp        | Op.regexp     | Regexp (MySQL and PG only)
+| notRegexp     | Op.notRegexp  | Not Regexp (MySQL and PG only)
+| iRegexp       | Op.iRegexp    | iRegexp (case insensitive) (PG only)
+| notIRegexp    | Op.notIRegexp | notIRegexp (case insensitive) (PG only)
 
 ## Configuration
 

--- a/src/where-builder.js
+++ b/src/where-builder.js
@@ -1,5 +1,6 @@
 const BuilderAbstract = require('./builder-abstract');
 const helper = require('./helper');
+const { Op } = require('sequelize');
 
 const allowedConditions = ['gt', 'gte', 'lt', 'lte', 'ne', 'like', 'notLike', 'iLike', 'notILike', 'regexp', 'notRegexp', 'iRegexp', 'notIRegexp'];
 const allowedConditionsArray = ['between', 'notBetween', 'in', 'notIn'];
@@ -21,21 +22,19 @@ class WhereBuilder extends BuilderAbstract {
         }
       }
     });
-
     return this._getConditionQuery(query, request);
   }
 
   _getConditionQuery(query, request) {
     const { Sequelize } = this;
     let conditionQuery = {};
-
     if (typeof request._condition === 'string') {
       conditionQuery = {
-        [Sequelize.Op[request._condition]]: query,
+        [Op[request._condition]]: query,
       };
     } else if (Array.isArray(query) && query.length > 1) {
       conditionQuery = {
-        [Sequelize.Op.and]: query,
+        [Op.and]: query,
       };
     } else {
       conditionQuery = query;
@@ -61,7 +60,7 @@ class WhereBuilder extends BuilderAbstract {
         || (allowedConditionsArray.includes(key) && Array.isArray(value))) {
           fieldQuery.push({
             [fieldKey]: {
-              [Sequelize.Op[key]]: value,
+              [Op[key]]: value,
             },
           });
         } else {

--- a/test/data/condition.js
+++ b/test/data/condition.js
@@ -1,4 +1,4 @@
-const Sequelize = require('sequelize');
+const { Op } = require('sequelize');
 
 module.exports = [
   {
@@ -11,15 +11,15 @@ module.exports = [
       },
     },
     expected: {
-      [Sequelize.Op.and]: [
+      [Op.and]: [
         {
           key: {
-            [Sequelize.Op.gt]: 10,
+            [Op.gt]: 10,
           },
         },
         {
           key: {
-            [Sequelize.Op.lt]: 100,
+            [Op.lt]: 100,
           },
         },
       ],
@@ -29,15 +29,15 @@ module.exports = [
     it: 'Condition with one field with _condition AND parameter (string)',
     request: 'filter[key][gt]=10&filter[key][lt]=100&filter[key][_condition]=and',
     expected: {
-      [Sequelize.Op.and]: [
+      [Op.and]: [
         {
           key: {
-            [Sequelize.Op.gt]: '10',
+            [Op.gt]: '10',
           },
         },
         {
           key: {
-            [Sequelize.Op.lt]: '100',
+            [Op.lt]: '100',
           },
         },
       ],
@@ -52,15 +52,15 @@ module.exports = [
       },
     },
     expected: {
-      [Sequelize.Op.and]: [
+      [Op.and]: [
         {
           key: {
-            [Sequelize.Op.gt]: 10,
+            [Op.gt]: 10,
           },
         },
         {
           key: {
-            [Sequelize.Op.lt]: 100,
+            [Op.lt]: 100,
           },
         },
       ],
@@ -70,15 +70,15 @@ module.exports = [
     it: 'Condition with one field without _condition AND parameter (string)',
     request: 'filter[key][gt]=10&filter[key][lt]=100&filter[key]',
     expected: {
-      [Sequelize.Op.and]: [
+      [Op.and]: [
         {
           key: {
-            [Sequelize.Op.gt]: '10',
+            [Op.gt]: '10',
           },
         },
         {
           key: {
-            [Sequelize.Op.lt]: '100',
+            [Op.lt]: '100',
           },
         },
       ],
@@ -94,15 +94,15 @@ module.exports = [
       },
     },
     expected: {
-      [Sequelize.Op.or]: [
+      [Op.or]: [
         {
           key: {
-            [Sequelize.Op.gt]: 10,
+            [Op.gt]: 10,
           },
         },
         {
           key: {
-            [Sequelize.Op.lt]: 100,
+            [Op.lt]: 100,
           },
         },
       ],
@@ -122,18 +122,18 @@ module.exports = [
       _condition: 'or',
     },
     expected: {
-      [Sequelize.Op.or]: {
-        [Sequelize.Op.or]: [{
+      [Op.or]: {
+        [Op.or]: [{
           key1: {
-            [Sequelize.Op.gt]: 10,
+            [Op.gt]: 10,
           },
         }, {
           key1: {
-            [Sequelize.Op.lt]: 100,
+            [Op.lt]: 100,
           },
         }],
         key2: {
-          [Sequelize.Op.like]: '%value%',
+          [Op.like]: '%value%',
         },
       },
     },
@@ -142,18 +142,18 @@ module.exports = [
     it: 'Condition with several fields with _condition OR parameter (string)',
     request: 'filter[key1][gt]=10&filter[key1][lt]=100&filter[key1][_condition]=or&filter[key2][like]=%value%&filter[_condition]=or',
     expected: {
-      [Sequelize.Op.or]: {
-        [Sequelize.Op.or]: [{
+      [Op.or]: {
+        [Op.or]: [{
           key1: {
-            [Sequelize.Op.gt]: '10',
+            [Op.gt]: '10',
           },
         }, {
           key1: {
-            [Sequelize.Op.lt]: '100',
+            [Op.lt]: '100',
           },
         }],
         key2: {
-          [Sequelize.Op.like]: '%value%',
+          [Op.like]: '%value%',
         },
       },
     },

--- a/test/data/where-builder/between.js
+++ b/test/data/where-builder/between.js
@@ -1,4 +1,4 @@
-const Sequelize = require('sequelize');
+const { Op } = require('sequelize');
 
 module.exports = [
   {
@@ -10,7 +10,7 @@ module.exports = [
     },
     expected: {
       key: {
-        [Sequelize.Op.between]: [1, 2],
+        [Op.between]: [1, 2],
       },
     },
   },
@@ -23,7 +23,7 @@ module.exports = [
     },
     expected: {
       '$key.key$': {
-        [Sequelize.Op.between]: [1, 2],
+        [Op.between]: [1, 2],
       },
     },
   },
@@ -39,10 +39,10 @@ module.exports = [
     },
     expected: {
       key1: {
-        [Sequelize.Op.between]: [1, 2],
+        [Op.between]: [1, 2],
       },
       key2: {
-        [Sequelize.Op.between]: [1, 2],
+        [Op.between]: [1, 2],
       },
     },
   },

--- a/test/data/where-builder/equal.js
+++ b/test/data/where-builder/equal.js
@@ -1,4 +1,4 @@
-const Sequelize = require('sequelize');
+const { Op } = require('sequelize');
 
 module.exports = [
   {
@@ -58,7 +58,7 @@ module.exports = [
       key2: 'value2',
     },
     expected: {
-      [Sequelize.Op.or]: {
+      [Op.or]: {
         key1: 'value1',
         key2: 'value2',
       },
@@ -72,7 +72,7 @@ module.exports = [
       key2: 'value2',
     },
     expected: {
-      [Sequelize.Op.or]: {
+      [Op.or]: {
         key1: 'value1',
         key2: 'value2',
       },
@@ -127,7 +127,7 @@ module.exports = [
       },
     },
     expected: {
-      [Sequelize.Op.or]: {
+      [Op.or]: {
         key1: 'value1',
         key2: 'value2',
       },
@@ -145,7 +145,7 @@ module.exports = [
       },
     },
     expected: {
-      [Sequelize.Op.and]: {
+      [Op.and]: {
         key1: 'value1',
         key2: 'value2',
       },
@@ -155,7 +155,7 @@ module.exports = [
     it: '(string request) Equal operator with AND condition (?filter[key1][eq]=value1&filter[key2][eq]=value2&filter[_condition]=and)',
     request: 'filter[key1][eq]=value1&filter[key2][eq]=value2&filter[_condition]=and',
     expected: {
-      [Sequelize.Op.and]: {
+      [Op.and]: {
         key1: 'value1',
         key2: 'value2',
       },

--- a/test/data/where-builder/gt.js
+++ b/test/data/where-builder/gt.js
@@ -1,4 +1,4 @@
-const Sequelize = require('sequelize');
+const { Op } = require('sequelize');
 
 module.exports = [
   {
@@ -10,7 +10,7 @@ module.exports = [
     },
     expected: {
       key: {
-        [Sequelize.Op.gt]: 'value',
+        [Op.gt]: 'value',
       },
     },
   },
@@ -23,7 +23,7 @@ module.exports = [
     },
     expected: {
       '$key.key$': {
-        [Sequelize.Op.gt]: 'value',
+        [Op.gt]: 'value',
       },
     },
   },
@@ -39,10 +39,10 @@ module.exports = [
     },
     expected: {
       key1: {
-        [Sequelize.Op.gt]: 'value1',
+        [Op.gt]: 'value1',
       },
       key2: {
-        [Sequelize.Op.gt]: 'value2',
+        [Op.gt]: 'value2',
       },
     },
   },

--- a/test/data/where-builder/gte.js
+++ b/test/data/where-builder/gte.js
@@ -1,4 +1,4 @@
-const Sequelize = require('sequelize');
+const { Op } = require('sequelize');
 
 module.exports = [
   {
@@ -10,7 +10,7 @@ module.exports = [
     },
     expected: {
       key: {
-        [Sequelize.Op.gte]: 'value',
+        [Op.gte]: 'value',
       },
     },
   },
@@ -23,7 +23,7 @@ module.exports = [
     },
     expected: {
       '$key.key$': {
-        [Sequelize.Op.gte]: 'value',
+        [Op.gte]: 'value',
       },
     },
   },
@@ -39,10 +39,10 @@ module.exports = [
     },
     expected: {
       key1: {
-        [Sequelize.Op.gte]: 'value1',
+        [Op.gte]: 'value1',
       },
       key2: {
-        [Sequelize.Op.gte]: 'value2',
+        [Op.gte]: 'value2',
       },
     },
   },

--- a/test/data/where-builder/iLike.js
+++ b/test/data/where-builder/iLike.js
@@ -1,4 +1,4 @@
-const Sequelize = require('sequelize');
+const { Op } = require('sequelize');
 
 module.exports = [
   {
@@ -10,7 +10,7 @@ module.exports = [
     },
     expected: {
       key: {
-        [Sequelize.Op.iLike]: 'value',
+        [Op.iLike]: 'value',
       },
     },
   },
@@ -23,7 +23,7 @@ module.exports = [
     },
     expected: {
       '$key.key$': {
-        [Sequelize.Op.iLike]: 'value',
+        [Op.iLike]: 'value',
       },
     },
   },
@@ -39,10 +39,10 @@ module.exports = [
     },
     expected: {
       key1: {
-        [Sequelize.Op.iLike]: 'value1',
+        [Op.iLike]: 'value1',
       },
       key2: {
-        [Sequelize.Op.iLike]: 'value2',
+        [Op.iLike]: 'value2',
       },
     },
   },

--- a/test/data/where-builder/iRegexp.js
+++ b/test/data/where-builder/iRegexp.js
@@ -1,4 +1,4 @@
-const Sequelize = require('sequelize');
+const { Op } = require('sequelize');
 
 module.exports = [
   {
@@ -10,7 +10,7 @@ module.exports = [
     },
     expected: {
       key: {
-        [Sequelize.Op.iRegexp]: 'value',
+        [Op.iRegexp]: 'value',
       },
     },
   },

--- a/test/data/where-builder/in.js
+++ b/test/data/where-builder/in.js
@@ -1,4 +1,4 @@
-const Sequelize = require('sequelize');
+const { Op } = require('sequelize');
 
 module.exports = [
   {
@@ -10,7 +10,7 @@ module.exports = [
     },
     expected: {
       key: {
-        [Sequelize.Op.in]: [1, 2],
+        [Op.in]: [1, 2],
       },
     },
   },
@@ -23,7 +23,7 @@ module.exports = [
     },
     expected: {
       '$key.key$': {
-        [Sequelize.Op.in]: [1, 2],
+        [Op.in]: [1, 2],
       },
     },
   },
@@ -39,10 +39,10 @@ module.exports = [
     },
     expected: {
       key1: {
-        [Sequelize.Op.in]: [1, 2],
+        [Op.in]: [1, 2],
       },
       key2: {
-        [Sequelize.Op.in]: [1, 2, 3],
+        [Op.in]: [1, 2, 3],
       },
     },
   },

--- a/test/data/where-builder/like.js
+++ b/test/data/where-builder/like.js
@@ -1,4 +1,4 @@
-const Sequelize = require('sequelize');
+const { Op } = require('sequelize');
 
 module.exports = [
   {
@@ -10,7 +10,7 @@ module.exports = [
     },
     expected: {
       key: {
-        [Sequelize.Op.like]: 'value',
+        [Op.like]: 'value',
       },
     },
   },
@@ -23,7 +23,7 @@ module.exports = [
     },
     expected: {
       '$key.key$': {
-        [Sequelize.Op.like]: 'value',
+        [Op.like]: 'value',
       },
     },
   },
@@ -39,10 +39,10 @@ module.exports = [
     },
     expected: {
       key1: {
-        [Sequelize.Op.like]: 'value1',
+        [Op.like]: 'value1',
       },
       key2: {
-        [Sequelize.Op.like]: 'value2',
+        [Op.like]: 'value2',
       },
     },
   },

--- a/test/data/where-builder/lt.js
+++ b/test/data/where-builder/lt.js
@@ -1,4 +1,4 @@
-const Sequelize = require('sequelize');
+const { Op } = require('sequelize');
 
 module.exports = [
   {
@@ -10,7 +10,7 @@ module.exports = [
     },
     expected: {
       key: {
-        [Sequelize.Op.lt]: 'value',
+        [Op.lt]: 'value',
       },
     },
   },
@@ -23,7 +23,7 @@ module.exports = [
     },
     expected: {
       '$key.key$': {
-        [Sequelize.Op.lt]: 'value',
+        [Op.lt]: 'value',
       },
     },
   },
@@ -39,10 +39,10 @@ module.exports = [
     },
     expected: {
       key1: {
-        [Sequelize.Op.lt]: 'value1',
+        [Op.lt]: 'value1',
       },
       key2: {
-        [Sequelize.Op.lt]: 'value2',
+        [Op.lt]: 'value2',
       },
     },
   },

--- a/test/data/where-builder/lte.js
+++ b/test/data/where-builder/lte.js
@@ -1,4 +1,4 @@
-const Sequelize = require('sequelize');
+const { Op } = require('sequelize');
 
 module.exports = [
   {
@@ -10,7 +10,7 @@ module.exports = [
     },
     expected: {
       key: {
-        [Sequelize.Op.lte]: 'value',
+        [Op.lte]: 'value',
       },
     },
   },
@@ -23,7 +23,7 @@ module.exports = [
     },
     expected: {
       '$key.key$': {
-        [Sequelize.Op.lte]: 'value',
+        [Op.lte]: 'value',
       },
     },
   },
@@ -39,10 +39,10 @@ module.exports = [
     },
     expected: {
       key1: {
-        [Sequelize.Op.lte]: 'value1',
+        [Op.lte]: 'value1',
       },
       key2: {
-        [Sequelize.Op.lte]: 'value2',
+        [Op.lte]: 'value2',
       },
     },
   },

--- a/test/data/where-builder/ne.js
+++ b/test/data/where-builder/ne.js
@@ -1,4 +1,4 @@
-const Sequelize = require('sequelize');
+const { Op } = require('sequelize');
 
 module.exports = [
   {
@@ -10,7 +10,7 @@ module.exports = [
     },
     expected: {
       key: {
-        [Sequelize.Op.ne]: 'value',
+        [Op.ne]: 'value',
       },
     },
   },
@@ -23,7 +23,7 @@ module.exports = [
     },
     expected: {
       '$key.key$': {
-        [Sequelize.Op.ne]: 'value',
+        [Op.ne]: 'value',
       },
     },
   },
@@ -39,10 +39,10 @@ module.exports = [
     },
     expected: {
       key1: {
-        [Sequelize.Op.ne]: 'value1',
+        [Op.ne]: 'value1',
       },
       key2: {
-        [Sequelize.Op.ne]: 'value2',
+        [Op.ne]: 'value2',
       },
     },
   },

--- a/test/data/where-builder/notBetween.js
+++ b/test/data/where-builder/notBetween.js
@@ -1,4 +1,4 @@
-const Sequelize = require('sequelize');
+const { Op } = require('sequelize');
 
 module.exports = [
   {
@@ -10,7 +10,7 @@ module.exports = [
     },
     expected: {
       key: {
-        [Sequelize.Op.notBetween]: [1, 2],
+        [Op.notBetween]: [1, 2],
       },
     },
   },
@@ -23,7 +23,7 @@ module.exports = [
     },
     expected: {
       '$key.key$': {
-        [Sequelize.Op.notBetween]: [1, 2],
+        [Op.notBetween]: [1, 2],
       },
     },
   },
@@ -39,10 +39,10 @@ module.exports = [
     },
     expected: {
       key1: {
-        [Sequelize.Op.notBetween]: [1, 2],
+        [Op.notBetween]: [1, 2],
       },
       key2: {
-        [Sequelize.Op.notBetween]: [1, 2],
+        [Op.notBetween]: [1, 2],
       },
     },
   },

--- a/test/data/where-builder/notILike.js
+++ b/test/data/where-builder/notILike.js
@@ -1,4 +1,4 @@
-const Sequelize = require('sequelize');
+const { Op } = require('sequelize');
 
 module.exports = [
   {
@@ -10,7 +10,7 @@ module.exports = [
     },
     expected: {
       key: {
-        [Sequelize.Op.notILike]: 'value',
+        [Op.notILike]: 'value',
       },
     },
   },
@@ -23,7 +23,7 @@ module.exports = [
     },
     expected: {
       '$key.key$': {
-        [Sequelize.Op.notILike]: 'value',
+        [Op.notILike]: 'value',
       },
     },
   },
@@ -39,10 +39,10 @@ module.exports = [
     },
     expected: {
       key1: {
-        [Sequelize.Op.notILike]: 'value1',
+        [Op.notILike]: 'value1',
       },
       key2: {
-        [Sequelize.Op.notILike]: 'value2',
+        [Op.notILike]: 'value2',
       },
     },
   },

--- a/test/data/where-builder/notIRegexp.js
+++ b/test/data/where-builder/notIRegexp.js
@@ -1,4 +1,4 @@
-const Sequelize = require('sequelize');
+const { Op } = require('sequelize');
 
 module.exports = [
   {
@@ -10,7 +10,7 @@ module.exports = [
     },
     expected: {
       key: {
-        [Sequelize.Op.notIRegexp]: 'value',
+        [Op.notIRegexp]: 'value',
       },
     },
   },
@@ -19,7 +19,7 @@ module.exports = [
     request: 'filter[key][notIRegexp]=value',
     expected: {
       key: {
-        [Sequelize.Op.notIRegexp]: 'value',
+        [Op.notIRegexp]: 'value',
       },
     },
   },

--- a/test/data/where-builder/notIn.js
+++ b/test/data/where-builder/notIn.js
@@ -1,4 +1,4 @@
-const Sequelize = require('sequelize');
+const { Op } = require('sequelize');
 
 module.exports = [
   {
@@ -10,7 +10,7 @@ module.exports = [
     },
     expected: {
       key: {
-        [Sequelize.Op.notIn]: [1, 2],
+        [Op.notIn]: [1, 2],
       },
     },
   },
@@ -23,7 +23,7 @@ module.exports = [
     },
     expected: {
       '$key.key$': {
-        [Sequelize.Op.notIn]: [1, 2],
+        [Op.notIn]: [1, 2],
       },
     },
   },
@@ -39,10 +39,10 @@ module.exports = [
     },
     expected: {
       key1: {
-        [Sequelize.Op.notIn]: [1, 2],
+        [Op.notIn]: [1, 2],
       },
       key2: {
-        [Sequelize.Op.notIn]: [1, 2, 3],
+        [Op.notIn]: [1, 2, 3],
       },
     },
   },

--- a/test/data/where-builder/notLike.js
+++ b/test/data/where-builder/notLike.js
@@ -1,4 +1,4 @@
-const Sequelize = require('sequelize');
+const { Op } = require('sequelize');
 
 module.exports = [
   {
@@ -10,7 +10,7 @@ module.exports = [
     },
     expected: {
       key: {
-        [Sequelize.Op.notLike]: 'value',
+        [Op.notLike]: 'value',
       },
     },
   },
@@ -23,7 +23,7 @@ module.exports = [
     },
     expected: {
       '$key.key$': {
-        [Sequelize.Op.notLike]: 'value',
+        [Op.notLike]: 'value',
       },
     },
   },
@@ -39,10 +39,10 @@ module.exports = [
     },
     expected: {
       key1: {
-        [Sequelize.Op.notLike]: 'value1',
+        [Op.notLike]: 'value1',
       },
       key2: {
-        [Sequelize.Op.notLike]: 'value2',
+        [Op.notLike]: 'value2',
       },
     },
   },

--- a/test/data/where-builder/notRegexp.js
+++ b/test/data/where-builder/notRegexp.js
@@ -1,4 +1,4 @@
-const Sequelize = require('sequelize');
+const { Op } = require('sequelize');
 
 module.exports = [
   {
@@ -10,7 +10,7 @@ module.exports = [
     },
     expected: {
       key: {
-        [Sequelize.Op.notRegexp]: 'value',
+        [Op.notRegexp]: 'value',
       },
     },
   },

--- a/test/data/where-builder/regexp.js
+++ b/test/data/where-builder/regexp.js
@@ -1,4 +1,4 @@
-const Sequelize = require('sequelize');
+const { Op } = require('sequelize');
 
 module.exports = [
   {
@@ -10,7 +10,7 @@ module.exports = [
     },
     expected: {
       key: {
-        [Sequelize.Op.regexp]: 'value',
+        [Op.regexp]: 'value',
       },
     },
   },


### PR DESCRIPTION
There are compatibility issues with sequelize 5+ version. The "Op" attribute isn't exported in the Sequelize object anymore. The tests works but I didn't check the compatibilty with the older versions of sequelize